### PR TITLE
Relocate @swc/core from dependencies to devDependencies

### DIFF
--- a/.changeset/great-bugs-provide.md
+++ b/.changeset/great-bugs-provide.md
@@ -1,0 +1,5 @@
+---
+"storybook-addon-swc": minor
+---
+
+Relocate @swc/core from dependencies to devDependencies and peerDependencies

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Storybook addon that improves build time by building with swc.
 ## 🚀 Installation
 
 ```
-$ npm install -D storybook-addon-swc
+$ npm install -D storybook-addon-swc @swc/core
 ```
 
 ## 👏 Getting Started

--- a/package.json
+++ b/package.json
@@ -70,15 +70,18 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
-    "@swc/core": "^1.2.152",
     "deepmerge": "^4.2.2",
     "swc-loader": "^0.1.15"
   },
   "peerDependencies": {
+    "@swc/core": "^1.2.152",
     "terser-webpack-plugin": "^4.0.0 || ^5.0.0",
     "webpack": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
+    "@swc/core": {
+      "optional": false
+    },
     "terser-webpack-plugin": {
       "optional": true
     },
@@ -95,6 +98,7 @@
     "@changesets/cli": "^2.21.0",
     "@preconstruct/cli": "^2.1.5",
     "@storybook/core-common": "^6.4.19",
+    "@swc/core": "^1.2.152",
     "@swc/jest": "^0.2.17",
     "@types/jest": "^27.4.0",
     "@types/webpack": "^5.28.0",


### PR DESCRIPTION
## 🛠 Refactor: Relocate @swc/core dependency

### 🔄 Changes
- Remove @swc/core from `dependencies`
- Add @swc/core to `devDependencies` and `peerDependencies`

### 🎯 Motivation
The refactoring allows users to independently install any version of @swc/core, providing more flexibility in managing dependency versions. This is especially helpful for fixing the version of @swc/core when working with unstable plugins, ensuring better compatibility and stability.